### PR TITLE
fix for "merge is not a function"

### DIFF
--- a/inst/template/build/webpack.app.config.js
+++ b/inst/template/build/webpack.app.config.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const merge = require("webpack-merge");
+const { merge }  = require("webpack-merge");
 const base = require("./webpack.base.config");
 
 module.exports = env => {

--- a/inst/template/build/webpack.e2e.config.js
+++ b/inst/template/build/webpack.e2e.config.js
@@ -1,4 +1,4 @@
-const merge = require("webpack-merge");
+const { merge } = require("webpack-merge");
 const jetpack = require("fs-jetpack");
 const base = require("./webpack.base.config");
 

--- a/inst/template/build/webpack.unit.config.js
+++ b/inst/template/build/webpack.unit.config.js
@@ -1,4 +1,4 @@
-const merge = require("webpack-merge");
+const { merge } = require("webpack-merge");
 const jetpack = require("fs-jetpack");
 const base = require("./webpack.base.config");
 


### PR DESCRIPTION
Currently, importing of the merge library in some of the webpack javascript files is broken - looks like some recent change results in the necessity to put "merge" between brackets.